### PR TITLE
[BUGFIX] Install libcgi-pm-perl

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@ package "gitweb"
 
 include_recipe "apache2::mod_perl"
 include_recipe "apache2::mod_cgid" if node['gitweb']['export-http']
+package "libcgi-pm-perl"
 
 if node['gitweb']['ssl']
   include_recipe "apache2::mod_ssl"


### PR DESCRIPTION
While Gitweb works without that package, the following message appears in the
syslog every time it is accessed otherwise:

> gerrit[32362]: [2017-12-15 13:47:15,857] [Gitweb-ErrorLogger] ERROR com.google.gerrit.httpd.gitweb.GitwebServlet : CGI: CGI will be removed from the Perl core distribution in the next major release. Please install the separate libcgi-pm-perl package. It is being used at /usr/lib/cgi-bin/gitweb.cgi, line 13.